### PR TITLE
vscodeの設定とformatの設定追加

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,14 +7,8 @@ module.exports = {
   parserOptions: {
     parser: 'babel-eslint',
   },
-  extends: [
-    '@nuxtjs',
-    'prettier',
-    'prettier/vue',
-    'plugin:prettier/recommended',
-    'plugin:nuxt/recommended',
-  ],
-  plugins: ['prettier'],
+  extends: ['@nuxtjs', 'prettier', 'prettier/vue', 'plugin:nuxt/recommended'],
+  plugins: [],
   // add your custom rules here
   rules: {},
 }

--- a/.vscode/_vue.code-snippets
+++ b/.vscode/_vue.code-snippets
@@ -1,0 +1,34 @@
+// vscode snippets
+// 使い方 ↓
+// https://rfs.jp/sb/vsc/vsc-snippet.html
+// ${0}に補完後のカーソルの位置が入ります。その他特殊なやつは、上のリンク or Google を参照してください。
+// 正規表現が使えます。正規表現については Googel or 下記リンク参照
+// https://murashun.jp/article/programming/regular-expression.html
+
+{
+  // サジェストに表示される名前
+  "script": {
+    // 呼び出すトリガー
+    "prefix": "script",
+    // 展開されるコード
+    "body": [
+      "<script>",
+      "export default {",
+      "\t${0}",
+      "}",
+      "</script>"
+    ],
+    // snipettsの説明文
+    "description": "<script>"
+  },
+  // この下に続ける
+  "template": {
+    "prefix": "template",
+    "body": [
+      "<template>",
+      "\t${0}",
+      "</template>"
+    ],
+    "description": "<template>"
+  }
+}

--- a/.vscode/_vue.code-snippets
+++ b/.vscode/_vue.code-snippets
@@ -30,5 +30,14 @@
       "</template>"
     ],
     "description": "<template>"
+  },
+  "comment": {
+    "prefix": "/**/",
+    "body": [
+      "/*",
+      "\t${0}",
+      "*/"
+    ],
+    "description": "複数行のコメント"
   }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "stylelint.vscode-stylelint"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "stylelint.vscode-stylelint"
+    "stylelint.vscode-stylelint",
+    "bradlc.vscode-tailwindcss",
+    "sdras.vue-vscode-snippets"
   ]
 }

--- a/.vscode/setting.json
+++ b/.vscode/setting.json
@@ -1,0 +1,19 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true
+  },
+  "eslint.validate": ["javascript", "vue", "vue-html", "html"],
+  "vetur.format.enable": false,
+  "html.format.enable": false,
+  "vetur.validation.template": false,
+  "javascript.format.enable": false,
+  "json.format.enable": false,
+  "vetur.validation.script": false,
+  "stylelint.enable": true,
+  "css.validate": false,
+  "scss.validate": false,
+  "vetur.validation.style": false
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-nuxt": "^2.0.0",
-    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^7.4.1",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "yarn lint:eslint --fix && yarn lint:prettier --write && yarn lint:style --fix"
   },
   "lint-staged": {
+    "*.{js,vue,json}": "prettier -c",
     "*.{js,vue}": "eslint",
     "*.{css,vue}": "stylelint"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3763,13 +3763,6 @@ eslint-plugin-nuxt@^2.0.0:
     semver "^7.3.2"
     vue-eslint-parser "^7.1.1"
 
-eslint-plugin-prettier@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
-  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-promise@^4.2.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz#61485df2a359e03149fdafc0a68b0e030ad2ac45"
@@ -4102,11 +4095,6 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.5"
@@ -7712,13 +7700,6 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@^1.18.2:
   version "1.19.1"


### PR DESCRIPTION
## 👏 Resolved Issues
close #12 

## 😋 Purpose
このプルリクは、vscodeの設定をチーム内で共有することと、保存時にフォーマットを良い感じにすることを目的としています。

## ⛏ Details of Changes
- Vscodeの拡張機能で、セーブ時にフォーマットが自動修正するようにした
-  ↑ で利用している拡張機能を、Vscodeからおすすめされるように
- eslint-plugin-prettierが非推奨らしいので消した
- lint-stagedにprettierが入ってなかったので追加した。
- vscode snippetsを導入した

## 📘 Specification
- `.vscode`ディレクトリに、設定ファイルを設置することで、このリポジトリ内でvscodeの設定を共有できます。
  - `.setting.json`ファイル内で、`OnSave`がついているものがセーブ時に実行されるものです。 
    - `eslint.validate`以下で他のフォーマッターとの競合が起こらないようにしています。
      - こうすると、prettierをvscodeでもコマンドでも実行できて、かつその他のフォーマッターが関与しないので、コードのフォーマットが統一されます。
  - `extensions.json`内で、保存時に実行するLinter、Formatterのvscode拡張機能を書いています。このファイル内に書かれた拡張機能は、vscode起動時に右下におすすめの拡張機能として表示され、一斉インストールすることができます。
    - vscodeの拡張機能は一つ一つ識別子っていうのがついててそれを書けばokです。識別子は名称の横に書いてます。
    - ついでに、Tailwind CSS の補完とかをやってくれる拡張機能と、vue-snippetsの拡張機能もインストールされるようにしました。
  - `.code-snippets`ファイルでsnippetsを定義しています。ここで、補完機能を良い感じにできます。

## 🤔 Concern
僕が自動セーブにしているからか、セーブしてもフォーマットがいい感じにならんかったりする。
コピペとかするとピン！ってフォーマットが整ったり。  
lint-stagedではじかれたら`yarn format`すればまあ

## 🗣️  Review request
- `setting.json`の中身いけてそうか
- セーブ時にフォーマットちゃんと整うかどうか

## ⏭️ Do After
- `yarn install` で依存関係の同期
- pullした後、vscode再起動して、右下に出てくるおすすめ拡張機能をインストールする
- esLintエラーが出てたら、承認ダイアログから承認する。
  - エラー箇所でカーソルかざす→修正するみたいなやつ→okみたいなやつ

## 📚 Reference
- [Prettier と ESLint の組み合わせの公式推奨が変わり plugin が不要になった](https://blog.ojisan.io/prettier-eslint-cli)
- [【Nuxt.js】ESLintの設定とVSCodeで保存時に自動整形する方法](https://qiita.com/k_kind/items/e2f07f70c9e4455b9902)
- [スニペットの登録 - Visual Studio Code - [SMART]](https://rfs.jp/sb/vsc/vsc-snippet.html)