### PR TITLE
ログインできるようにする

### DIFF
--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -1,0 +1,6 @@
+export default function ({ store, redirect }) {
+  // 認証が必要なページにアクセスしたらログインページへリダイレクト
+  if (!store.state.auth) {
+    return redirect('/admin/login')
+  }
+}

--- a/middleware/notAuthenticated.js
+++ b/middleware/notAuthenticated.js
@@ -1,0 +1,7 @@
+export default function ({ store, redirect }) {
+  // 認証不要ページ用
+  // もし認証済みなら、管理ページへリダイレクト
+  if (store.state.auth) {
+    return redirect('/admin')
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -56,6 +56,7 @@ export default {
         services: {
           firestore: true,
           analytics: true,
+          auth: true,
         },
       },
     ],

--- a/pages/admin/login.vue
+++ b/pages/admin/login.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <h1 class="text-center text-3xl mt-16 text-gray-800">
+      管理者ページへアクセスするには、dloppのアカウントでログインしてください。
+    </h1>
+    <form class="container max-w-md mx-auto mt-20">
+      <div class="mb-4">
+        <label class="block text-gray-700 text-sm font-bold mb-2" for="email">
+          Email
+        </label>
+        <input
+          id="name"
+          v-model="email"
+          class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          type="text"
+          placeholder="Email"
+        />
+      </div>
+      <div class="mb-4">
+        <label
+          class="block text-gray-700 text-sm font-bold mb-2"
+          for="password"
+        >
+          Password
+        </label>
+        <input
+          id="password"
+          v-model="password"
+          class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          type="password"
+          placeholder="password"
+        />
+      </div>
+      <div class="flex items-center justify-between">
+        <button
+          class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          @click.prevent="login"
+        >
+          login
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+export default {
+  middleware: 'notAuthenticated',
+
+  data() {
+    return {
+      email: '',
+      password: '',
+    }
+  },
+
+  methods: {
+    async login() {
+      // 入力がなかった時
+      if (!this.email.length || !this.password.length) {
+        this.$toast.error('入力してください')
+        return
+      }
+      const auth = await this.$fire.auth
+        .signInWithEmailAndPassword(this.email, this.password)
+        .catch(() => {
+          // メアドとパスワードが間違ってた時
+          this.$toast.error('メールアドレスまたはパスワードが間違っています。')
+          return null
+        })
+      // あってたら、authをstoreにcommitして保持
+      if (auth) {
+        this.$store.commit('mutateAuth', auth)
+        this.$router.push('/admin/questions')
+      }
+    },
+  },
+}
+</script>

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,13 @@
+export const strict = false
+
+export const state = () => ({
+  // ユーザー情報の保持
+  auth: null,
+})
+
+export const mutations = {
+  // ログイン時にユーザー情報を入れ、ログアウト時はnullを入れて認証情報を削除する
+  mutateAuth(state, auth) {
+    state.auth = auth
+  },
+}


### PR DESCRIPTION
## 👏 Resolved Issues
close #6

## 📘 Specification
```js
middleware: authenticated
```
がついてるページに認証なしでアクセスすると、ログインページリダイレクトされます。
認証は、dloppのメアドとパスワードです。
僕らしか見ないページなので、適当なところからフォームとってきました。下に置いときます。

- @nuxtjs/toastモジュール(完了メッセージだすやつ)を使っていますが、別プルリクでinstallしているので、このプルリクだけやと正常に動作しません。

## 📚 Reference
フォームデザイン
- [最高のFormを探せ!! 🔎 CSSフレームワークのFormコンポーネントを比較してみる](https://qiita.com/ryo2132/items/3ef8fb0def001d308490)

認証機能
- [nuxt/nuxtjs/examples/auth](https://github.com/nuxt/nuxt.js/tree/dev/examples/auth-jwt)
