### PR TITLE
認証情報をCookieに保存する

### DIFF
--- a/middleware/notAuthenticated.js
+++ b/middleware/notAuthenticated.js
@@ -2,6 +2,6 @@ export default function ({ store, redirect }) {
   // 認証不要ページ用
   // もし認証済みなら、管理ページへリダイレクト
   if (store.state.auth) {
-    return redirect('/admin')
+    return redirect('/admin/questions')
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,6 @@
 export default {
-  // Target: https://go.nuxtjs.dev/config-target
-  target: 'static',
+  // SSR: https://go.nuxtjs.dev/config-ssr
+  ssr: true,
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
   },
   "dependencies": {
     "@nuxtjs/firebase": "^7.5.0",
+    "cookieparser": "^0.1.0",
     "core-js": "^3.8.2",
     "firebase": "^8.3.0",
+    "js-cookie": "^2.2.1",
     "nuxt": "^2.14.12"
   },
   "devDependencies": {

--- a/pages/admin/login.vue
+++ b/pages/admin/login.vue
@@ -44,6 +44,8 @@
 </template>
 
 <script>
+const Cookie = process.client ? require('js-cookie') : undefined
+
 export default {
   middleware: 'notAuthenticated',
 
@@ -70,7 +72,8 @@ export default {
         })
       // あってたら、authをstoreにcommitして保持
       if (auth) {
-        this.$store.commit('mutateAuth', auth)
+        this.$store.commit('mutateAuth', auth) // csr
+        Cookie.set('auth', auth) // ssr
         this.$router.push('/admin/questions')
       }
     },

--- a/pages/admin/questions/_id.vue
+++ b/pages/admin/questions/_id.vue
@@ -26,6 +26,7 @@
 
 <script>
 export default {
+  middleware: 'authenticated',
   // 質問内容を取得する処理
   async asyncData({ app, params }) {
     const questionDoc = await app.$fire.firestore

--- a/pages/admin/questions/index.vue
+++ b/pages/admin/questions/index.vue
@@ -1,15 +1,20 @@
 <template>
-  <ul>
-    <li v-for="(question, index) in questions" :key="index">
-      <nuxt-link :to="'/admin/questions/' + question.id">{{
-        question.body
-      }}</nuxt-link>
-      <span v-if="question.isReplied">回答済み</span>
-    </li>
-  </ul>
+  <div>
+    <button @click="logout">ログアウト</button>
+    <ul>
+      <li v-for="(question, index) in questions" :key="index">
+        <nuxt-link :to="'/admin/questions/' + question.id">{{
+          question.body
+        }}</nuxt-link>
+        <span v-if="question.isReplied">回答済み</span>
+      </li>
+    </ul>
+  </div>
 </template>
 
 <script>
+const Cookie = process.client ? require('js-cookie') : undefined
+
 export default {
   middleware: 'authenticated',
   async asyncData({ app }) {
@@ -26,6 +31,14 @@ export default {
         })
       })
     return { questions }
+  },
+  methods: {
+    logout() {
+      Cookie.remove('auth')
+      this.$store.commit('mutateAuth', null)
+      this.$fire.auth.signOut()
+      this.$router.push('/admin/login')
+    },
   },
 }
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,6 @@
-export const strict = false
+const cookieparser = process.server ? require('cookieparser') : undefined
+
+export const strict = false // 一旦のerror回避
 
 export const state = () => ({
   // ユーザー情報の保持
@@ -9,5 +11,25 @@ export const mutations = {
   // ログイン時にユーザー情報を入れ、ログアウト時はnullを入れて認証情報を削除する
   mutateAuth(state, auth) {
     state.auth = auth
+  },
+}
+
+export const actions = {
+  // cookieに保存した認証情報をサーバー側で扱えるようにする処理
+  nuxtServerInit({ commit }, { req }) {
+    let auth = null
+    if (req.headers.cookie) {
+      // cookieのauthをjsonで取得
+      const parsed = cookieparser.parse(req.headers.cookie)
+      try {
+        // 認証情報を取得
+        auth = JSON.parse(parsed.auth)
+      } catch (err) {
+        // 認証情報なしのとき、firebaseもログアウト
+        this.$fire.auth.signOut()
+      }
+    }
+    // 認証 or null
+    commit('mutateAuth', auth)
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,11 @@ cookie@^0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
+cookieparser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/cookieparser/-/cookieparser-0.1.0.tgz#ea12cb1085c174f3167faeaf7985f79abe671d0e"
+  integrity sha1-6hLLEIXBdPMWf66veYX3mr5nHQ4=
+
 cookies@~0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
@@ -6215,6 +6220,11 @@ jiti@^1.3.0:
   integrity sha512-riTFltg08xtufghxm4Ve6ITghk+rtg7gqD4YvH0LyjqMSxREG9sJmXGbJ2spNkUPdpl37QqjeQ0w0BtS70yNPA==
   dependencies:
     "@types/semver" "^7.3.4"
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## 👏 Resolved Issues
close #26 

## 📘 Specification
- 認証情報をCookieに保存して、ログアウトするまでは基本的にログインされたままになるようになっています。
- ログイン時にログインページにアクセス→管理者ページにリダイレクト
- ログアウト時に管理者ページにアクセス→ログイン画面にリダイレクト

## 📚 Reference
- [nuxt/nuxtjs/examples/auth](https://github.com/nuxt/nuxt.js/tree/dev/examples/auth-jwt)