### PR TITLE
コンポーネントの参照方法ミスってた

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <Container>
+    <LayoutsContainer>
       <Nuxt />
-    </Container>
+    </LayoutsContainer>
   </div>
 </template>
 


### PR DESCRIPTION
## 🐛 Bugfix
/components/Hoge/Fuga.vue
の時は、
`<HogeFuga />`
ってする

## 📚 Reference
[コンポーネント - NuxtJS](https://ja.nuxtjs.org/docs/2.x/directory-structure/components/)