### PR TITLE
ogp画像を追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,7 +27,7 @@ export default {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: '',
+        content: 'https://dlopp-questionbox.netlify.app',
       },
       {
         hid: 'og:title',

--- a/pages/answers/_id.vue
+++ b/pages/answers/_id.vue
@@ -37,17 +37,17 @@ export default {
         {
           hid: 'og:url',
           property: 'og:url',
-          content: '',
+          content: `https://dlopp-questionbox.netlify.app/answers/${this.answer.id}`,
         },
         {
           hid: 'og:image',
           property: 'og:image',
-          content: '',
+          content: `https://res.cloudinary.com/dxfzpd78t/image/upload/l_text:ozopbvhnoiumgyir0pgk.ttf_35:${this.question.body},co_rgb:333,w_600,c_fit/v1617435093/ogp1_y1qzqf.png`,
         },
         {
           hid: 'twitter:image',
           property: 'twitter:image',
-          content: '',
+          content: `https://res.cloudinary.com/dxfzpd78t/image/upload/l_text:ozopbvhnoiumgyir0pgk.ttf_35:${this.question.body},co_rgb:333,w_600,c_fit/v1617435093/ogp1_y1qzqf.png`,
         },
       ],
     }


### PR DESCRIPTION
## 👏  Resolved Issues
close #5 

## ⛏ Details of Changes
- 動的OGP画像をCloudinaryを使って実装した
- [Cloudinary](https://cloudinary.com/)は、dloppのGoogleアカウントでログインできます。

## 🤔 Concern
OGPチェッカーが動作しなかったので、一旦デプロイしてから動作確認する。

## 📚 Reference
- [Cloudinaryで動的にOGP画像を生成する方法](Cloudinaryで動的にOGP画像を生成する方法)
- [All Google fonts not supported? - Cloudinary Support](https://support.cloudinary.com/hc/en-us/community/posts/360036102992-All-Google-fonts-not-supported-)